### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 import argparse
 import discord

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-python-Levenshtein
 discord-py
 plotly
 requests
-fuzzywuzzy
+rapidfuzz
 shutil


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy